### PR TITLE
add compatibility with 8.7

### DIFF
--- a/3rdparty/polyorder.v
+++ b/3rdparty/polyorder.v
@@ -105,10 +105,7 @@ Qed.
 Lemma muP p x n : p != 0 ->
   (('X - x%:P)^+n %| p) && ~~(('X - x%:P)^+n.+1 %| p) = (n == \mu_x p).
 Proof.
-move=> hp0; rewrite !root_le_mu//; case: (ltngtP n (\mu_x p))=> hn.
-+ by rewrite ltnW//=.
-+ by rewrite leqNgt hn.
-+ by rewrite hn leqnn.
+move=> hp0; rewrite !root_le_mu//; case: (ltngtP n (\mu_x p))=> hn ; solve[auto] ; by [rewrite ltnW//= | rewrite leqNgt hn | rewrite hn leqnn].
 Qed.
 
 Lemma mu_gt0 p x : p != 0 -> (0 < \mu_x p)%N = root p x.


### PR DESCRIPTION
Provide compatibility with coq 8.7 (with retro compatibility 8.6) under the assumption that https://github.com/math-comp/finmap is compatible with 8.7.
The `opam` will need to be modified to accept `coq-mathcomp-ssreflect dev` and  `coq-mathcomp-multinomials dev`.
