### PR TITLE
fix implicit argument syntax for Coq 8.9

### DIFF
--- a/common/polyfrac.v
+++ b/common/polyfrac.v
@@ -39,7 +39,7 @@ Section Defs.
   (*~option G / use newType instead ? *)
   Inductive gproj (G : Type) : Type := GP_Finite of G | GP_Inf.
 
-  Implicit Arguments GP_Inf [G].
+  Arguments GP_Inf [G].
 
   Implicit Types p : gproj G.
 

--- a/common/ssrring.v
+++ b/common/ssrring.v
@@ -189,7 +189,7 @@ Definition R_of_Z (R : ringType) (z : Z) : R :=
   | Zneg n => - (nat_of_P n)%:R
   end.
 
-Implicit Arguments R_of_Z [R].
+Arguments R_of_Z [R].
 
 Lemma eqposP (x y : positive): reflect (x = y) (Peqb x y).
 Proof. by apply: (iffP idP); move/Peqb_eq. Qed.

--- a/src/ecorder.v
+++ b/src/ecorder.v
@@ -1732,7 +1732,7 @@ Section ECPolyRoots.
     by rewrite -eceval_mul // conjp_normp ecX_eceval.
   Qed.
 
-  Implicit Arguments ecroot_normp [f x].
+  Arguments ecroot_normp [f x].
 
   Lemma ecroots_order f x y:
     ((x, y) \in ecroots f) = (order f%:F (|x, y|) != 0).


### PR DESCRIPTION
This project currently does not build with Coq 8.9 due to implicit argument syntax deprecation. Here is a fix.